### PR TITLE
Add Makefile

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -26,15 +26,15 @@ jobs:
 
       - name: Cross-compile Go programs
         run: |
-          GOOS=darwin GOARCH=arm64 go build -o build/mangathr_arm64-darwin ./cmd/mangathr
-          GOOS=darwin GOARCH=amd64 go build -o build/mangathr_amd64-darwin ./cmd/mangathr
-          GOOS=linux GOARCH=arm64 go build -o build/mangathr_arm64-linux ./cmd/mangathr
-          GOOS=linux GOARCH=amd64 go build -o build/mangathr_amd64-linux ./cmd/mangathr
+          set -eu -o pipefail
+          
+          make cross-build VERSION="${{ github.ref_name }}"
+          make dist VERSION="${{ github.ref_name }}"
 
-      - name: Upload binaries to release
+      - name: Upload archives to release
         uses: svenstaro/upload-release-action@v2
         with:
-          file: build/mangathr_*
+          file: dist/*.{zip,tar.gz}
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 **/.DS_Store
 build/**
+dist/**
+bin/**
 downloads/**
 *.sqlite
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,89 @@
+BINDIR       := $(CURDIR)/bin
+INSTALL_PATH ?= /usr/local/bin
+DIST_DIRS    := find * -type d -exec
+PLATFORMS    := darwin/arm64 darwin/amd64 linux/arm64 linux/amd64
+BINNAME      ?= mangathr
+
+# go
+PKG         := ./...
+LDFLAGS     := -w -s
+
+# Rebuild the binary if any of these files change
+SRC := $(shell find . -type f -name '*.go' -print) go.mod go.sum
+
+SHELL      = /usr/bin/env sh
+
+# git
+GIT_COMMIT = $(shell git rev-parse HEAD)
+GIT_SHA    = $(shell git rev-parse --short HEAD)
+GIT_TAG    = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
+LDFLAGS   += -X github.com/browningluke/mangathr/v2/internal/version.sha=${GIT_SHA}
+
+ifdef VERSION
+	BINARY_VERSION = $(VERSION)
+endif
+BINARY_VERSION ?= ${GIT_TAG}
+
+# Only set Version if building a tag or VERSION is set
+ifneq ($(BINARY_VERSION),)
+	LDFLAGS += -X github.com/browningluke/mangathr/v2/internal/version.version=${BINARY_VERSION}
+endif
+
+# Default target
+.PHONY: all
+all: build
+
+
+# build
+
+.PHONY: build
+build: $(BINDIR)/$(BINNAME)
+
+$(BINDIR)/$(BINNAME): $(SRC)
+	go build -trimpath -ldflags '$(LDFLAGS)' -o '$(BINDIR)'/$(BINNAME) ./cmd/mangathr
+
+# install
+
+.PHONY: install
+install: build
+	@install "$(BINDIR)/$(BINNAME)" "$(INSTALL_PATH)/$(BINNAME)"
+
+
+# Release
+
+# Build for all platforms
+cross-build: LDFLAGS += -extldflags "-static"
+cross-build: $(PLATFORMS)
+	@echo "Build complete for all platforms."
+
+# Define the build rule for each platform
+$(PLATFORMS):
+	@platform=$@; \
+	GOARCH=$$(echo $$platform | cut -d'/' -f2) ; \
+	GOOS=$$(echo $$platform | cut -d'/' -f1) ; \
+	echo "Building for $$GOOS/$$GOARCH"; \
+	mkdir -p dist/$$GOOS-$$GOARCH; \
+	go build -o dist/$$GOOS-$$GOARCH/ -trimpath -ldflags '$(LDFLAGS)' $(PKG)
+
+.PHONY: dist
+dist:
+	( \
+		cd dist && \
+		$(DIST_DIRS) cp ../LICENSE {} \; && \
+		$(DIST_DIRS) cp ../README.md {} \; && \
+		$(DIST_DIRS) tar -czf mangathr-${VERSION}-{}.tar.gz {} \; && \
+		$(DIST_DIRS) zip -r mangathr-${VERSION}-{}.zip {} \; \
+	)
+
+
+# Misc
+
+.PHONY: clean
+clean:
+	@rm -rf '$(BINDIR)' ./dist
+
+.PHONY: info
+info:
+	@echo "Version:           ${VERSION}"
+	@echo "Git Tag:           ${GIT_TAG}"
+	@echo "Git Commit:        ${GIT_COMMIT}"

--- a/cmd/mangathr/version/version.go
+++ b/cmd/mangathr/version/version.go
@@ -3,6 +3,8 @@ package version
 import (
 	"fmt"
 	"github.com/browningluke/mangathr/v2/internal/config"
+	"github.com/browningluke/mangathr/v2/internal/utils"
+	"github.com/browningluke/mangathr/v2/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +15,18 @@ func NewCmd(_ *config.Config) *cobra.Command {
 		Aliases: []string{"v"},
 		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("mangathr v2.2.0 -- HEAD")
+			containerStr := ""
+
+			if utils.IsRunningInContainer() {
+				containerStr = "-docker"
+			}
+
+			fmt.Printf(
+				"mangathr %s%s -- %s\n",
+				version.GetVersion(),
+				containerStr,
+				version.GetSHA(),
+			)
 		},
 		DisableFlagsInUseLine: true,
 	}

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -3,12 +3,11 @@ FROM golang:1.22-alpine AS build
 
 WORKDIR /app
 
-COPY ../../go.mod ./
-COPY ../../go.sum ./
-RUN go mod download && go mod verify
+# Add build dependencies
+RUN apk add make git
 
 COPY ../../ .
-RUN go build -v -o /mangathr ./cmd/mangathr
+RUN make
 
 ENTRYPOINT ["mangathr"]
 
@@ -19,6 +18,7 @@ WORKDIR /
 
 RUN mkdir config data
 
-COPY --from=build /mangathr /mangathr
+COPY --from=build /app/bin/mangathr /usr/local/bin/mangathr
 
-ENTRYPOINT ["/mangathr"]
+ENTRYPOINT ["mangathr"]
+

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,14 @@
+package version
+
+var (
+	version = "dev"
+	sha     = "N/A"
+)
+
+func GetVersion() string {
+	return version
+}
+
+func GetSHA() string {
+	return sha
+}


### PR DESCRIPTION
Adding a Makefile allows dynamically setting the version string at compile time, as well as streamlining the entire build workflow.

- **Generate string for version cmd at compile time**
- **Add Makefile to build + cross-build**
- **Update .gitignore with new build locations**
- **Use Makefile build in Dockerfile**
- **Update GHA to use Makefile**
