### PR TITLE
Add ability to exclude chapters based on groups

### DIFF
--- a/cmd/mangathr/manage/list.go
+++ b/cmd/mangathr/manage/list.go
@@ -35,11 +35,13 @@ func printList(driver *database.Driver, sourceFilter string, titleFilter []strin
 				"  Source:          %s\n"+
 				"  Mapping:         %s\n"+
 				"  Filtered Groups: %s\n"+
+				"  Excluded Groups: %s\n"+
 				"\n",
 			m.Title,
 			m.Source,
 			m.Mapping,
 			m.FilteredGroups,
+			m.ExcludedGroups,
 		)
 	}
 }

--- a/cmd/mangathr/register/run.go
+++ b/cmd/mangathr/register/run.go
@@ -24,7 +24,8 @@ func closeDatabase() {
 type options struct {
 	title          string
 	mapping        string
-	filteredGroups []string
+	includedGroups []string
+	excludedGroups []string
 	scraper        *sources.Scraper
 }
 
@@ -78,7 +79,8 @@ func findManga(args *registerOpts) (options, bool) {
 		title:          mangaTitle,
 		mapping:        downloader.CleanPath(mangaTitle),
 		scraper:        &scraper,
-		filteredGroups: []string{},
+		includedGroups: []string{},
+		excludedGroups: []string{},
 	}
 
 	if exists, _ := driver.CheckMangaExistence(scraper.MangaID()); exists {
@@ -173,7 +175,7 @@ func handleMenu(args *registerOpts, driver *database.Driver) {
 				mangaID := (*opts.scraper).MangaID()
 				source := (*opts.scraper).ScraperName()
 
-				manga, err := driver.CreateManga(mangaID, opts.title, source, opts.mapping, opts.filteredGroups)
+				manga, err := driver.CreateManga(mangaID, opts.title, source, opts.mapping, opts.includedGroups, opts.excludedGroups)
 				if err != nil {
 					logging.ExitIfErrorWithFunc(&logging.ScraperError{
 						Error: err, Message: "An error occurred when adding Manga to database", Code: 0,

--- a/cmd/mangathr/register/run.go
+++ b/cmd/mangathr/register/run.go
@@ -34,6 +34,14 @@ func generateString(opts *options, prompt string) string {
 	logging.ExitIfErrorWithFunc(err, closeDatabase)
 	source := (*opts.scraper).ScraperName()
 
+	latestChapter := "N/A"
+	firstChapter := "N/A"
+
+	if len(chapterTitles) > 0 {
+		latestChapter = chapterTitles[0]
+		firstChapter = chapterTitles[len(chapterTitles)-1]
+	}
+
 	return fmt.Sprintf(
 		"\rTitle: %s"+
 			"\nSource: %s"+
@@ -44,8 +52,8 @@ func generateString(opts *options, prompt string) string {
 			"\nIncluded groups: [%s]"+
 			"\nExcluded groups: [%s]"+
 			"\n%s",
-		opts.title, source, len(chapterTitles), chapterTitles[0],
-		chapterTitles[len(chapterTitles)-1], opts.mapping,
+		opts.title, source, len(chapterTitles),
+		latestChapter, firstChapter, opts.mapping,
 		strings.Join(opts.includedGroups, ", "),
 		strings.Join(opts.excludedGroups, ", "), prompt)
 }

--- a/cmd/mangathr/update/run.go
+++ b/cmd/mangathr/update/run.go
@@ -75,7 +75,7 @@ func checkMangaForNewChapters(manga *ent.Manga) (seriesStats, *logging.ScraperEr
 	}
 
 	// Filter groups
-	scraper.FilterGroups(manga.FilteredGroups)
+	scraper.FilterGroups(manga.FilteredGroups, manga.ExcludedGroups)
 
 	// Select new chapters in scraper, get array of them; and download if > 0
 	newChapters, err := scraper.SelectNewChapters(chapterIDs)

--- a/ent/manga.go
+++ b/ent/manga.go
@@ -30,6 +30,8 @@ type Manga struct {
 	RegisteredOn time.Time `json:"RegisteredOn,omitempty"`
 	// FilteredGroups holds the value of the "FilteredGroups" field.
 	FilteredGroups []string `json:"FilteredGroups,omitempty"`
+	// ExcludedGroups holds the value of the "ExcludedGroups" field.
+	ExcludedGroups []string `json:"ExcludedGroups,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the MangaQuery when eager-loading is set.
 	Edges        MangaEdges `json:"edges"`
@@ -59,7 +61,7 @@ func (*Manga) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case manga.FieldFilteredGroups:
+		case manga.FieldFilteredGroups, manga.FieldExcludedGroups:
 			values[i] = new([]byte)
 		case manga.FieldID:
 			values[i] = new(sql.NullInt64)
@@ -126,6 +128,14 @@ func (m *Manga) assignValues(columns []string, values []any) error {
 					return fmt.Errorf("unmarshal field FilteredGroups: %w", err)
 				}
 			}
+		case manga.FieldExcludedGroups:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field ExcludedGroups", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &m.ExcludedGroups); err != nil {
+					return fmt.Errorf("unmarshal field ExcludedGroups: %w", err)
+				}
+			}
 		default:
 			m.selectValues.Set(columns[i], values[i])
 		}
@@ -184,6 +194,9 @@ func (m *Manga) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("FilteredGroups=")
 	builder.WriteString(fmt.Sprintf("%v", m.FilteredGroups))
+	builder.WriteString(", ")
+	builder.WriteString("ExcludedGroups=")
+	builder.WriteString(fmt.Sprintf("%v", m.ExcludedGroups))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/ent/manga/manga.go
+++ b/ent/manga/manga.go
@@ -24,6 +24,8 @@ const (
 	FieldRegisteredOn = "registered_on"
 	// FieldFilteredGroups holds the string denoting the filteredgroups field in the database.
 	FieldFilteredGroups = "filtered_groups"
+	// FieldExcludedGroups holds the string denoting the excludedgroups field in the database.
+	FieldExcludedGroups = "excluded_groups"
 	// EdgeChapters holds the string denoting the chapters edge name in mutations.
 	EdgeChapters = "Chapters"
 	// Table holds the table name of the manga in the database.
@@ -46,6 +48,7 @@ var Columns = []string{
 	FieldMapping,
 	FieldRegisteredOn,
 	FieldFilteredGroups,
+	FieldExcludedGroups,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).

--- a/ent/manga/manga.go
+++ b/ent/manga/manga.go
@@ -61,6 +61,13 @@ func ValidColumn(column string) bool {
 	return false
 }
 
+var (
+	// DefaultFilteredGroups holds the default value on creation for the "FilteredGroups" field.
+	DefaultFilteredGroups []string
+	// DefaultExcludedGroups holds the default value on creation for the "ExcludedGroups" field.
+	DefaultExcludedGroups []string
+)
+
 // OrderOption defines the ordering options for the Manga queries.
 type OrderOption func(*sql.Selector)
 

--- a/ent/manga/where.go
+++ b/ent/manga/where.go
@@ -380,6 +380,26 @@ func RegisteredOnLTE(v time.Time) predicate.Manga {
 	return predicate.Manga(sql.FieldLTE(FieldRegisteredOn, v))
 }
 
+// FilteredGroupsIsNil applies the IsNil predicate on the "FilteredGroups" field.
+func FilteredGroupsIsNil() predicate.Manga {
+	return predicate.Manga(sql.FieldIsNull(FieldFilteredGroups))
+}
+
+// FilteredGroupsNotNil applies the NotNil predicate on the "FilteredGroups" field.
+func FilteredGroupsNotNil() predicate.Manga {
+	return predicate.Manga(sql.FieldNotNull(FieldFilteredGroups))
+}
+
+// ExcludedGroupsIsNil applies the IsNil predicate on the "ExcludedGroups" field.
+func ExcludedGroupsIsNil() predicate.Manga {
+	return predicate.Manga(sql.FieldIsNull(FieldExcludedGroups))
+}
+
+// ExcludedGroupsNotNil applies the NotNil predicate on the "ExcludedGroups" field.
+func ExcludedGroupsNotNil() predicate.Manga {
+	return predicate.Manga(sql.FieldNotNull(FieldExcludedGroups))
+}
+
 // HasChapters applies the HasEdge predicate on the "Chapters" edge.
 func HasChapters() predicate.Manga {
 	return predicate.Manga(func(s *sql.Selector) {

--- a/ent/manga_create.go
+++ b/ent/manga_create.go
@@ -57,6 +57,12 @@ func (mc *MangaCreate) SetFilteredGroups(s []string) *MangaCreate {
 	return mc
 }
 
+// SetExcludedGroups sets the "ExcludedGroups" field.
+func (mc *MangaCreate) SetExcludedGroups(s []string) *MangaCreate {
+	mc.mutation.SetExcludedGroups(s)
+	return mc
+}
+
 // AddChapterIDs adds the "Chapters" edge to the Chapter entity by IDs.
 func (mc *MangaCreate) AddChapterIDs(ids ...int) *MangaCreate {
 	mc.mutation.AddChapterIDs(ids...)
@@ -124,6 +130,9 @@ func (mc *MangaCreate) check() error {
 	if _, ok := mc.mutation.FilteredGroups(); !ok {
 		return &ValidationError{Name: "FilteredGroups", err: errors.New(`ent: missing required field "Manga.FilteredGroups"`)}
 	}
+	if _, ok := mc.mutation.ExcludedGroups(); !ok {
+		return &ValidationError{Name: "ExcludedGroups", err: errors.New(`ent: missing required field "Manga.ExcludedGroups"`)}
+	}
 	return nil
 }
 
@@ -173,6 +182,10 @@ func (mc *MangaCreate) createSpec() (*Manga, *sqlgraph.CreateSpec) {
 	if value, ok := mc.mutation.FilteredGroups(); ok {
 		_spec.SetField(manga.FieldFilteredGroups, field.TypeJSON, value)
 		_node.FilteredGroups = value
+	}
+	if value, ok := mc.mutation.ExcludedGroups(); ok {
+		_spec.SetField(manga.FieldExcludedGroups, field.TypeJSON, value)
+		_node.ExcludedGroups = value
 	}
 	if nodes := mc.mutation.ChaptersIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/ent/manga_create.go
+++ b/ent/manga_create.go
@@ -85,6 +85,7 @@ func (mc *MangaCreate) Mutation() *MangaMutation {
 
 // Save creates the Manga in the database.
 func (mc *MangaCreate) Save(ctx context.Context) (*Manga, error) {
+	mc.defaults()
 	return withHooks(ctx, mc.sqlSave, mc.mutation, mc.hooks)
 }
 
@@ -110,6 +111,18 @@ func (mc *MangaCreate) ExecX(ctx context.Context) {
 	}
 }
 
+// defaults sets the default values of the builder before save.
+func (mc *MangaCreate) defaults() {
+	if _, ok := mc.mutation.FilteredGroups(); !ok {
+		v := manga.DefaultFilteredGroups
+		mc.mutation.SetFilteredGroups(v)
+	}
+	if _, ok := mc.mutation.ExcludedGroups(); !ok {
+		v := manga.DefaultExcludedGroups
+		mc.mutation.SetExcludedGroups(v)
+	}
+}
+
 // check runs all checks and user-defined validators on the builder.
 func (mc *MangaCreate) check() error {
 	if _, ok := mc.mutation.MangaID(); !ok {
@@ -126,12 +139,6 @@ func (mc *MangaCreate) check() error {
 	}
 	if _, ok := mc.mutation.RegisteredOn(); !ok {
 		return &ValidationError{Name: "RegisteredOn", err: errors.New(`ent: missing required field "Manga.RegisteredOn"`)}
-	}
-	if _, ok := mc.mutation.FilteredGroups(); !ok {
-		return &ValidationError{Name: "FilteredGroups", err: errors.New(`ent: missing required field "Manga.FilteredGroups"`)}
-	}
-	if _, ok := mc.mutation.ExcludedGroups(); !ok {
-		return &ValidationError{Name: "ExcludedGroups", err: errors.New(`ent: missing required field "Manga.ExcludedGroups"`)}
 	}
 	return nil
 }
@@ -224,6 +231,7 @@ func (mcb *MangaCreateBulk) Save(ctx context.Context) ([]*Manga, error) {
 	for i := range mcb.builders {
 		func(i int, root context.Context) {
 			builder := mcb.builders[i]
+			builder.defaults()
 			var mut Mutator = MutateFunc(func(ctx context.Context, m Mutation) (Value, error) {
 				mutation, ok := m.(*MangaMutation)
 				if !ok {

--- a/ent/manga_update.go
+++ b/ent/manga_update.go
@@ -112,6 +112,18 @@ func (mu *MangaUpdate) AppendFilteredGroups(s []string) *MangaUpdate {
 	return mu
 }
 
+// SetExcludedGroups sets the "ExcludedGroups" field.
+func (mu *MangaUpdate) SetExcludedGroups(s []string) *MangaUpdate {
+	mu.mutation.SetExcludedGroups(s)
+	return mu
+}
+
+// AppendExcludedGroups appends s to the "ExcludedGroups" field.
+func (mu *MangaUpdate) AppendExcludedGroups(s []string) *MangaUpdate {
+	mu.mutation.AppendExcludedGroups(s)
+	return mu
+}
+
 // AddChapterIDs adds the "Chapters" edge to the Chapter entity by IDs.
 func (mu *MangaUpdate) AddChapterIDs(ids ...int) *MangaUpdate {
 	mu.mutation.AddChapterIDs(ids...)
@@ -210,6 +222,14 @@ func (mu *MangaUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if value, ok := mu.mutation.AppendedFilteredGroups(); ok {
 		_spec.AddModifier(func(u *sql.UpdateBuilder) {
 			sqljson.Append(u, manga.FieldFilteredGroups, value)
+		})
+	}
+	if value, ok := mu.mutation.ExcludedGroups(); ok {
+		_spec.SetField(manga.FieldExcludedGroups, field.TypeJSON, value)
+	}
+	if value, ok := mu.mutation.AppendedExcludedGroups(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, manga.FieldExcludedGroups, value)
 		})
 	}
 	if mu.mutation.ChaptersCleared() {
@@ -359,6 +379,18 @@ func (muo *MangaUpdateOne) AppendFilteredGroups(s []string) *MangaUpdateOne {
 	return muo
 }
 
+// SetExcludedGroups sets the "ExcludedGroups" field.
+func (muo *MangaUpdateOne) SetExcludedGroups(s []string) *MangaUpdateOne {
+	muo.mutation.SetExcludedGroups(s)
+	return muo
+}
+
+// AppendExcludedGroups appends s to the "ExcludedGroups" field.
+func (muo *MangaUpdateOne) AppendExcludedGroups(s []string) *MangaUpdateOne {
+	muo.mutation.AppendExcludedGroups(s)
+	return muo
+}
+
 // AddChapterIDs adds the "Chapters" edge to the Chapter entity by IDs.
 func (muo *MangaUpdateOne) AddChapterIDs(ids ...int) *MangaUpdateOne {
 	muo.mutation.AddChapterIDs(ids...)
@@ -487,6 +519,14 @@ func (muo *MangaUpdateOne) sqlSave(ctx context.Context) (_node *Manga, err error
 	if value, ok := muo.mutation.AppendedFilteredGroups(); ok {
 		_spec.AddModifier(func(u *sql.UpdateBuilder) {
 			sqljson.Append(u, manga.FieldFilteredGroups, value)
+		})
+	}
+	if value, ok := muo.mutation.ExcludedGroups(); ok {
+		_spec.SetField(manga.FieldExcludedGroups, field.TypeJSON, value)
+	}
+	if value, ok := muo.mutation.AppendedExcludedGroups(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, manga.FieldExcludedGroups, value)
 		})
 	}
 	if muo.mutation.ChaptersCleared() {

--- a/ent/manga_update.go
+++ b/ent/manga_update.go
@@ -112,6 +112,12 @@ func (mu *MangaUpdate) AppendFilteredGroups(s []string) *MangaUpdate {
 	return mu
 }
 
+// ClearFilteredGroups clears the value of the "FilteredGroups" field.
+func (mu *MangaUpdate) ClearFilteredGroups() *MangaUpdate {
+	mu.mutation.ClearFilteredGroups()
+	return mu
+}
+
 // SetExcludedGroups sets the "ExcludedGroups" field.
 func (mu *MangaUpdate) SetExcludedGroups(s []string) *MangaUpdate {
 	mu.mutation.SetExcludedGroups(s)
@@ -121,6 +127,12 @@ func (mu *MangaUpdate) SetExcludedGroups(s []string) *MangaUpdate {
 // AppendExcludedGroups appends s to the "ExcludedGroups" field.
 func (mu *MangaUpdate) AppendExcludedGroups(s []string) *MangaUpdate {
 	mu.mutation.AppendExcludedGroups(s)
+	return mu
+}
+
+// ClearExcludedGroups clears the value of the "ExcludedGroups" field.
+func (mu *MangaUpdate) ClearExcludedGroups() *MangaUpdate {
+	mu.mutation.ClearExcludedGroups()
 	return mu
 }
 
@@ -224,6 +236,9 @@ func (mu *MangaUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			sqljson.Append(u, manga.FieldFilteredGroups, value)
 		})
 	}
+	if mu.mutation.FilteredGroupsCleared() {
+		_spec.ClearField(manga.FieldFilteredGroups, field.TypeJSON)
+	}
 	if value, ok := mu.mutation.ExcludedGroups(); ok {
 		_spec.SetField(manga.FieldExcludedGroups, field.TypeJSON, value)
 	}
@@ -231,6 +246,9 @@ func (mu *MangaUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		_spec.AddModifier(func(u *sql.UpdateBuilder) {
 			sqljson.Append(u, manga.FieldExcludedGroups, value)
 		})
+	}
+	if mu.mutation.ExcludedGroupsCleared() {
+		_spec.ClearField(manga.FieldExcludedGroups, field.TypeJSON)
 	}
 	if mu.mutation.ChaptersCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -379,6 +397,12 @@ func (muo *MangaUpdateOne) AppendFilteredGroups(s []string) *MangaUpdateOne {
 	return muo
 }
 
+// ClearFilteredGroups clears the value of the "FilteredGroups" field.
+func (muo *MangaUpdateOne) ClearFilteredGroups() *MangaUpdateOne {
+	muo.mutation.ClearFilteredGroups()
+	return muo
+}
+
 // SetExcludedGroups sets the "ExcludedGroups" field.
 func (muo *MangaUpdateOne) SetExcludedGroups(s []string) *MangaUpdateOne {
 	muo.mutation.SetExcludedGroups(s)
@@ -388,6 +412,12 @@ func (muo *MangaUpdateOne) SetExcludedGroups(s []string) *MangaUpdateOne {
 // AppendExcludedGroups appends s to the "ExcludedGroups" field.
 func (muo *MangaUpdateOne) AppendExcludedGroups(s []string) *MangaUpdateOne {
 	muo.mutation.AppendExcludedGroups(s)
+	return muo
+}
+
+// ClearExcludedGroups clears the value of the "ExcludedGroups" field.
+func (muo *MangaUpdateOne) ClearExcludedGroups() *MangaUpdateOne {
+	muo.mutation.ClearExcludedGroups()
 	return muo
 }
 
@@ -521,6 +551,9 @@ func (muo *MangaUpdateOne) sqlSave(ctx context.Context) (_node *Manga, err error
 			sqljson.Append(u, manga.FieldFilteredGroups, value)
 		})
 	}
+	if muo.mutation.FilteredGroupsCleared() {
+		_spec.ClearField(manga.FieldFilteredGroups, field.TypeJSON)
+	}
 	if value, ok := muo.mutation.ExcludedGroups(); ok {
 		_spec.SetField(manga.FieldExcludedGroups, field.TypeJSON, value)
 	}
@@ -528,6 +561,9 @@ func (muo *MangaUpdateOne) sqlSave(ctx context.Context) (_node *Manga, err error
 		_spec.AddModifier(func(u *sql.UpdateBuilder) {
 			sqljson.Append(u, manga.FieldExcludedGroups, value)
 		})
+	}
+	if muo.mutation.ExcludedGroupsCleared() {
+		_spec.ClearField(manga.FieldExcludedGroups, field.TypeJSON)
 	}
 	if muo.mutation.ChaptersCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -40,8 +40,8 @@ var (
 		{Name: "title", Type: field.TypeString},
 		{Name: "mapping", Type: field.TypeString},
 		{Name: "registered_on", Type: field.TypeTime},
-		{Name: "filtered_groups", Type: field.TypeJSON},
-		{Name: "excluded_groups", Type: field.TypeJSON},
+		{Name: "filtered_groups", Type: field.TypeJSON, Nullable: true},
+		{Name: "excluded_groups", Type: field.TypeJSON, Nullable: true},
 	}
 	// MangasTable holds the schema information for the "mangas" table.
 	MangasTable = &schema.Table{

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -41,6 +41,7 @@ var (
 		{Name: "mapping", Type: field.TypeString},
 		{Name: "registered_on", Type: field.TypeTime},
 		{Name: "filtered_groups", Type: field.TypeJSON},
+		{Name: "excluded_groups", Type: field.TypeJSON},
 	}
 	// MangasTable holds the schema information for the "mangas" table.
 	MangasTable = &schema.Table{

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -692,6 +692,8 @@ type MangaMutation struct {
 	_RegisteredOn         *time.Time
 	_FilteredGroups       *[]string
 	append_FilteredGroups []string
+	_ExcludedGroups       *[]string
+	append_ExcludedGroups []string
 	clearedFields         map[string]struct{}
 	_Chapters             map[int]struct{}
 	removed_Chapters      map[int]struct{}
@@ -1030,6 +1032,57 @@ func (m *MangaMutation) ResetFilteredGroups() {
 	m.append_FilteredGroups = nil
 }
 
+// SetExcludedGroups sets the "ExcludedGroups" field.
+func (m *MangaMutation) SetExcludedGroups(s []string) {
+	m._ExcludedGroups = &s
+	m.append_ExcludedGroups = nil
+}
+
+// ExcludedGroups returns the value of the "ExcludedGroups" field in the mutation.
+func (m *MangaMutation) ExcludedGroups() (r []string, exists bool) {
+	v := m._ExcludedGroups
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldExcludedGroups returns the old "ExcludedGroups" field's value of the Manga entity.
+// If the Manga object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *MangaMutation) OldExcludedGroups(ctx context.Context) (v []string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExcludedGroups is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExcludedGroups requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExcludedGroups: %w", err)
+	}
+	return oldValue.ExcludedGroups, nil
+}
+
+// AppendExcludedGroups adds s to the "ExcludedGroups" field.
+func (m *MangaMutation) AppendExcludedGroups(s []string) {
+	m.append_ExcludedGroups = append(m.append_ExcludedGroups, s...)
+}
+
+// AppendedExcludedGroups returns the list of values that were appended to the "ExcludedGroups" field in this mutation.
+func (m *MangaMutation) AppendedExcludedGroups() ([]string, bool) {
+	if len(m.append_ExcludedGroups) == 0 {
+		return nil, false
+	}
+	return m.append_ExcludedGroups, true
+}
+
+// ResetExcludedGroups resets all changes to the "ExcludedGroups" field.
+func (m *MangaMutation) ResetExcludedGroups() {
+	m._ExcludedGroups = nil
+	m.append_ExcludedGroups = nil
+}
+
 // AddChapterIDs adds the "Chapters" edge to the Chapter entity by ids.
 func (m *MangaMutation) AddChapterIDs(ids ...int) {
 	if m._Chapters == nil {
@@ -1118,7 +1171,7 @@ func (m *MangaMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *MangaMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m._MangaID != nil {
 		fields = append(fields, manga.FieldMangaID)
 	}
@@ -1136,6 +1189,9 @@ func (m *MangaMutation) Fields() []string {
 	}
 	if m._FilteredGroups != nil {
 		fields = append(fields, manga.FieldFilteredGroups)
+	}
+	if m._ExcludedGroups != nil {
+		fields = append(fields, manga.FieldExcludedGroups)
 	}
 	return fields
 }
@@ -1157,6 +1213,8 @@ func (m *MangaMutation) Field(name string) (ent.Value, bool) {
 		return m.RegisteredOn()
 	case manga.FieldFilteredGroups:
 		return m.FilteredGroups()
+	case manga.FieldExcludedGroups:
+		return m.ExcludedGroups()
 	}
 	return nil, false
 }
@@ -1178,6 +1236,8 @@ func (m *MangaMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldRegisteredOn(ctx)
 	case manga.FieldFilteredGroups:
 		return m.OldFilteredGroups(ctx)
+	case manga.FieldExcludedGroups:
+		return m.OldExcludedGroups(ctx)
 	}
 	return nil, fmt.Errorf("unknown Manga field %s", name)
 }
@@ -1228,6 +1288,13 @@ func (m *MangaMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetFilteredGroups(v)
+		return nil
+	case manga.FieldExcludedGroups:
+		v, ok := value.([]string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExcludedGroups(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Manga field %s", name)
@@ -1295,6 +1362,9 @@ func (m *MangaMutation) ResetField(name string) error {
 		return nil
 	case manga.FieldFilteredGroups:
 		m.ResetFilteredGroups()
+		return nil
+	case manga.FieldExcludedGroups:
+		m.ResetExcludedGroups()
 		return nil
 	}
 	return fmt.Errorf("unknown Manga field %s", name)

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -1026,10 +1026,24 @@ func (m *MangaMutation) AppendedFilteredGroups() ([]string, bool) {
 	return m.append_FilteredGroups, true
 }
 
+// ClearFilteredGroups clears the value of the "FilteredGroups" field.
+func (m *MangaMutation) ClearFilteredGroups() {
+	m._FilteredGroups = nil
+	m.append_FilteredGroups = nil
+	m.clearedFields[manga.FieldFilteredGroups] = struct{}{}
+}
+
+// FilteredGroupsCleared returns if the "FilteredGroups" field was cleared in this mutation.
+func (m *MangaMutation) FilteredGroupsCleared() bool {
+	_, ok := m.clearedFields[manga.FieldFilteredGroups]
+	return ok
+}
+
 // ResetFilteredGroups resets all changes to the "FilteredGroups" field.
 func (m *MangaMutation) ResetFilteredGroups() {
 	m._FilteredGroups = nil
 	m.append_FilteredGroups = nil
+	delete(m.clearedFields, manga.FieldFilteredGroups)
 }
 
 // SetExcludedGroups sets the "ExcludedGroups" field.
@@ -1077,10 +1091,24 @@ func (m *MangaMutation) AppendedExcludedGroups() ([]string, bool) {
 	return m.append_ExcludedGroups, true
 }
 
+// ClearExcludedGroups clears the value of the "ExcludedGroups" field.
+func (m *MangaMutation) ClearExcludedGroups() {
+	m._ExcludedGroups = nil
+	m.append_ExcludedGroups = nil
+	m.clearedFields[manga.FieldExcludedGroups] = struct{}{}
+}
+
+// ExcludedGroupsCleared returns if the "ExcludedGroups" field was cleared in this mutation.
+func (m *MangaMutation) ExcludedGroupsCleared() bool {
+	_, ok := m.clearedFields[manga.FieldExcludedGroups]
+	return ok
+}
+
 // ResetExcludedGroups resets all changes to the "ExcludedGroups" field.
 func (m *MangaMutation) ResetExcludedGroups() {
 	m._ExcludedGroups = nil
 	m.append_ExcludedGroups = nil
+	delete(m.clearedFields, manga.FieldExcludedGroups)
 }
 
 // AddChapterIDs adds the "Chapters" edge to the Chapter entity by ids.
@@ -1325,7 +1353,14 @@ func (m *MangaMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *MangaMutation) ClearedFields() []string {
-	return nil
+	var fields []string
+	if m.FieldCleared(manga.FieldFilteredGroups) {
+		fields = append(fields, manga.FieldFilteredGroups)
+	}
+	if m.FieldCleared(manga.FieldExcludedGroups) {
+		fields = append(fields, manga.FieldExcludedGroups)
+	}
+	return fields
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -1338,6 +1373,14 @@ func (m *MangaMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *MangaMutation) ClearField(name string) error {
+	switch name {
+	case manga.FieldFilteredGroups:
+		m.ClearFilteredGroups()
+		return nil
+	case manga.FieldExcludedGroups:
+		m.ClearExcludedGroups()
+		return nil
+	}
 	return fmt.Errorf("unknown Manga nullable field %s", name)
 }
 

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -2,8 +2,23 @@
 
 package ent
 
+import (
+	"github.com/browningluke/mangathr/v2/ent/manga"
+	"github.com/browningluke/mangathr/v2/ent/schema"
+)
+
 // The init function reads all schema descriptors with runtime code
 // (default values, validators, hooks and policies) and stitches it
 // to their package variables.
 func init() {
+	mangaFields := schema.Manga{}.Fields()
+	_ = mangaFields
+	// mangaDescFilteredGroups is the schema descriptor for FilteredGroups field.
+	mangaDescFilteredGroups := mangaFields[5].Descriptor()
+	// manga.DefaultFilteredGroups holds the default value on creation for the FilteredGroups field.
+	manga.DefaultFilteredGroups = mangaDescFilteredGroups.Default.([]string)
+	// mangaDescExcludedGroups is the schema descriptor for ExcludedGroups field.
+	mangaDescExcludedGroups := mangaFields[6].Descriptor()
+	// manga.DefaultExcludedGroups holds the default value on creation for the ExcludedGroups field.
+	manga.DefaultExcludedGroups = mangaDescExcludedGroups.Default.([]string)
 }

--- a/ent/schema/manga.go
+++ b/ent/schema/manga.go
@@ -20,6 +20,7 @@ func (Manga) Fields() []ent.Field {
 		field.String("Mapping"),
 		field.Time("RegisteredOn"),
 		field.Strings("FilteredGroups"),
+		field.Strings("ExcludedGroups"),
 	}
 }
 

--- a/ent/schema/manga.go
+++ b/ent/schema/manga.go
@@ -19,8 +19,8 @@ func (Manga) Fields() []ent.Field {
 		field.String("Title"),
 		field.String("Mapping"),
 		field.Time("RegisteredOn"),
-		field.Strings("FilteredGroups"),
-		field.Strings("ExcludedGroups"),
+		field.Strings("FilteredGroups").Default([]string{}).Optional(),
+		field.Strings("ExcludedGroups").Default([]string{}).Optional(),
 	}
 }
 

--- a/internal/database/create.go
+++ b/internal/database/create.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func (d *Driver) createManga(mangaID, title, source, mapping string, groups []string) (*ent.Manga, error) {
+func (d *Driver) createManga(mangaID, title, source, mapping string, filteredGroups []string, excludedGroups []string) (*ent.Manga, error) {
 	u, err := d.client.Manga.
 		Create().
 		SetMangaID(mangaID).
@@ -15,7 +15,8 @@ func (d *Driver) createManga(mangaID, title, source, mapping string, groups []st
 		SetSource(source).
 		SetMapping(mapping).
 		SetRegisteredOn(time.Now()).
-		SetFilteredGroups(groups).
+		SetFilteredGroups(filteredGroups).
+		SetExcludedGroups(excludedGroups).
 		Save(d.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating manga: %w", err)
@@ -24,10 +25,10 @@ func (d *Driver) createManga(mangaID, title, source, mapping string, groups []st
 	return u, nil
 }
 
-func (d *Driver) CreateManga(mangaID, title, source, mapping string, groups []string) (*ent.Manga, error) {
+func (d *Driver) CreateManga(mangaID, title, source, mapping string, filteredGroups []string, excludedGroups []string) (*ent.Manga, error) {
 	manga, err := d.QueryMangaByID(mangaID, source)
 	if err != nil {
-		return d.createManga(mangaID, title, source, mapping, groups)
+		return d.createManga(mangaID, title, source, mapping, filteredGroups, excludedGroups)
 	}
 	return manga, nil
 }

--- a/internal/sources/cubari/scraper.go
+++ b/internal/sources/cubari/scraper.go
@@ -18,6 +18,7 @@ const (
 type Scraper struct {
 	allChapters, selectedChapters,
 	filteredChapters []manga.Chapter
+	filtered bool
 
 	// pages URLs mapped by chapter ID
 	pages map[string][]string
@@ -29,7 +30,8 @@ type Scraper struct {
 func NewScraper() *Scraper {
 	logging.Debugln("Created a Cubari scraper")
 	s := &Scraper{
-		pages: make(map[string][]string),
+		pages:    make(map[string][]string),
+		filtered: false,
 	}
 	return s
 }
@@ -47,7 +49,7 @@ func (m *Scraper) SelectManga(_ string) *logging.ScraperError {
 // Chapters returns chapter data from Cubari's API
 func (m *Scraper) Chapters() ([]manga.Chapter, *logging.ScraperError) {
 	// If chapters have been filtered, only show the filtered chapters
-	if len(m.filteredChapters) != 0 {
+	if m.filtered {
 		return m.filteredChapters, nil
 	}
 
@@ -115,6 +117,8 @@ func (m *Scraper) FilterGroups(groups []string) *logging.ScraperError {
 	}
 
 	m.filteredChapters = filteredChapters
+	// Mark filtering done
+	m.filtered = true
 
 	return nil
 }

--- a/internal/sources/mangadex/scraper.go
+++ b/internal/sources/mangadex/scraper.go
@@ -23,6 +23,7 @@ type Scraper struct {
 
 	allChapters, selectedChapters,
 	filteredChapters []manga.Chapter
+	filtered bool
 
 	// Group queries
 	groups []string
@@ -40,7 +41,7 @@ func NewScraper() *Scraper {
 
 func (m *Scraper) Chapters() ([]manga.Chapter, *logging.ScraperError) {
 	// If chapters have been filtered, only show the filtered chapters
-	if len(m.filteredChapters) != 0 {
+	if m.filtered {
 		return m.filteredChapters, nil
 	}
 
@@ -109,6 +110,8 @@ func (m *Scraper) FilterGroups(groups []string) *logging.ScraperError {
 	}
 
 	m.filteredChapters = filteredChapters
+	// Mark filtering done
+	m.filtered = true
 
 	return nil
 }

--- a/internal/sources/scraperController.go
+++ b/internal/sources/scraperController.go
@@ -56,7 +56,7 @@ type Scraper interface {
 
 	// Setters
 
-	FilterGroups(groups []string) *logging.ScraperError
+	FilterGroups(includeGroups []string, excludeGroups []string) *logging.ScraperError
 
 	// Downloading
 


### PR DESCRIPTION
Currently there is a way to restrict `update` to only download chapters from a certain group. This PR expands this to allow ignoring chapters from a certain group.



- **Do not assume filter not applied when slice empty**
- **Add ExcludedGroups field to manga schema**
- **Default FilteredGroups + ExcludedGroups to empty array when null**
- **Update createManga helper func with excluded groups slice**
- **Add exclude parameter to Scraper FilterGroups**
- **Fix UI panic when registering manga with no chapters**
