### PR TITLE
Add include/exclude group config option for scrapers

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,19 @@ Available variables are (verbatim):
 
 ```yaml
 mangadex:
-  filenameTemplate: "..."                              # See config template section (overrides global template)
-  ratingFilter: ["safe", "suggestive", "erotica"]      # Show only these ratings when searching
-  languageFilter: ["en", "fr"]                         # Include chapters with these languages
-  dataSaver: false                                     # Use Mangadex's 'data saver' page size
+  filenameTemplate: "..."           # See config template section (overrides global template)
+  ratingFilter:                     # Show only these ratings when searching
+    - "safe"
+    - "suggestive"
+    - "erotica"
+  languageFilter: ["en", "fr"]      # Include chapters with these languages
+  dataSaver: false                  # Use Mangadex's 'data saver' page size
+  groups:
+    include:                        # Only download chapters from <Example A> and <Example B>
+      - "Example A"
+      - "Example B"
+    exclude:                        # Do not download chapters from <Example C>
+      - "Example C"
 ```
 
 ### Cubari
@@ -199,6 +208,12 @@ mangadex:
 ```yaml
 cubari:
   filenameTemplate: "..."      # See config template section (overrides global template)
+  groups:
+    include:                   # Only download chapters from <Example A> and <Example B>
+      - "Example A"
+      - "Example B"
+    exclude:                   # Do not download chapters from <Example C>
+      - "Example C"
 ```
 
 

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -38,5 +38,21 @@ sources:
     ratingFilter: ["safe", "suggestive", "erotica"]
     languageFilter: ["en"] # , "fr"
     dataSaver: false
+    groups:
+      # Only download chapters from <Example A> and <Example B>
+      # include:
+        # - "Example A"
+        # - "Example B"
+      # Do not download chapters from <Example C>
+      exclude:
+        - "Example C"
   cubari:
     filenameTemplate: "{num:4} - Chapter {num:2}{title: - <.>}{groups: {<.>}}" # Set specific for source (overrides global)
+    groups:
+      # Only download chapters from <Example A> and <Example B>
+      # include:
+      # - "Example A"
+      # - "Example B"
+      # Do not download chapters from <Example C>
+      exclude:
+        - "Example C"

--- a/internal/sources/cubari/config.go
+++ b/internal/sources/cubari/config.go
@@ -3,7 +3,14 @@ package cubari
 var config Config
 
 type Config struct {
+	// Scraper
 	FilenameTemplate string `yaml:"filenameTemplate"`
+
+	// Groups
+	Groups struct {
+		Include []string `yaml:"include"`
+		Exclude []string `yaml:"exclude"`
+	} `yaml:"groups"`
 }
 
 func SetConfig(cfg Config) {
@@ -12,4 +19,6 @@ func SetConfig(cfg Config) {
 
 func (c *Config) Default() {
 	c.FilenameTemplate = "" // No override of downloader.output.filenameTemplate
+	c.Groups.Include = []string{}
+	c.Groups.Exclude = []string{}
 }

--- a/internal/sources/cubari/scraper.go
+++ b/internal/sources/cubari/scraper.go
@@ -127,17 +127,21 @@ func (m *Scraper) FilterGroups(includeGroups []string, excludeGroups []string) *
 		return err
 	}
 
+	// Merge `groups` with config value
+	toInclude := utils.MergeSlices(includeGroups, config.Groups.Include)
+	toExclude := utils.MergeSlices(excludeGroups, config.Groups.Exclude)
+
 	// Start with all
 	chaptersToFilter := m.allChapters
 
 	// Include
-	if len(includeGroups) > 0 {
-		chaptersToFilter = filterGroups(chaptersToFilter, includeGroups, false)
+	if len(toInclude) > 0 {
+		chaptersToFilter = filterGroups(chaptersToFilter, toInclude, false)
 	}
 
 	// Exclude
-	if len(excludeGroups) > 0 {
-		chaptersToFilter = filterGroups(chaptersToFilter, excludeGroups, true)
+	if len(toExclude) > 0 {
+		chaptersToFilter = filterGroups(chaptersToFilter, toExclude, true)
 	}
 
 	m.filteredChapters = chaptersToFilter

--- a/internal/sources/mangadex/config.go
+++ b/internal/sources/mangadex/config.go
@@ -9,6 +9,12 @@ type Config struct {
 	LanguageFilter   []string `yaml:"languageFilter"`
 	DataSaver        bool     `yaml:"dataSaver"`
 
+	// Groups
+	Groups struct {
+		Include []string `yaml:"include"`
+		Exclude []string `yaml:"exclude"`
+	} `yaml:"groups"`
+
 	// Connection
 	SyncDeletions bool `yaml:"syncDeletions"`
 }
@@ -22,6 +28,9 @@ func (c *Config) Default() {
 	c.RatingFilter = []string{"safe", "suggestive"}
 	c.LanguageFilter = []string{"en"}
 	c.DataSaver = false
+
+	c.Groups.Include = []string{}
+	c.Groups.Exclude = []string{}
 
 	c.SyncDeletions = false
 }

--- a/internal/sources/mangadex/scraper.go
+++ b/internal/sources/mangadex/scraper.go
@@ -3,6 +3,7 @@ package mangadex
 import (
 	"github.com/browningluke/mangathr/v2/internal/logging"
 	"github.com/browningluke/mangathr/v2/internal/manga"
+	"github.com/browningluke/mangathr/v2/internal/utils"
 )
 
 const (
@@ -122,17 +123,21 @@ func (m *Scraper) FilterGroups(includeGroups []string, excludeGroups []string) *
 		return err
 	}
 
+	// Merge `groups` with config value
+	toInclude := utils.MergeSlices(includeGroups, config.Groups.Include)
+	toExclude := utils.MergeSlices(excludeGroups, config.Groups.Exclude)
+
 	// Start with all
 	chaptersToFilter := m.allChapters
 
 	// Include
-	if len(includeGroups) > 0 {
-		chaptersToFilter = filterGroups(chaptersToFilter, includeGroups, false)
+	if len(toInclude) > 0 {
+		chaptersToFilter = filterGroups(chaptersToFilter, toInclude, false)
 	}
 
 	// Exclude
-	if len(excludeGroups) > 0 {
-		chaptersToFilter = filterGroups(chaptersToFilter, excludeGroups, true)
+	if len(toExclude) > 0 {
+		chaptersToFilter = filterGroups(chaptersToFilter, toExclude, true)
 	}
 
 	m.filteredChapters = chaptersToFilter

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -49,6 +49,27 @@ func findInSlice(list interface{}, match interface{}, stringFold bool) (interfac
 	return nil, false
 }
 
+// MergeSlices merges multiple slices and removes duplicates.
+func MergeSlices[K comparable](slices ...[]K) []K {
+	// Create a map to keep track of unique elements
+	uniqueElements := make(map[K]struct{})
+
+	// Iterate over each slice
+	for _, slice := range slices {
+		for _, value := range slice {
+			uniqueElements[value] = struct{}{}
+		}
+	}
+
+	// Convert map keys to a slice
+	var result []K
+	for key := range uniqueElements {
+		result = append(result, key)
+	}
+
+	return result
+}
+
 func PadString(s string, length int) string {
 	stringSlice := strings.Split(s, ".")
 	s = stringSlice[0]


### PR DESCRIPTION
Rather than having to include/exclude groups for each manga registered, this PR provides the config option to globally (per source) set the groups to include / exclude - from which `mangathr update` will then ignore. 

- **Add include/exclude groups config for dex + cb scraper**
- **Merge groups from config when filtering**
- **Add groups config example to README**
