### PR TITLE
Fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/internal/database/driver.go
+++ b/internal/database/driver.go
@@ -52,7 +52,14 @@ func GetDriver() (*Driver, error) {
 	}
 
 	// Open driver
-	logging.Debugln("Opening database `", driverName, "` with options: ", options)
+	if driverName == dialect.Postgres {
+		redactedOptions := fmt.Sprintf("host=%s port=%s user=%s password=**** dbname=%s sslmode=%s %s",
+			config.Postgres.Host, config.Postgres.Port, config.Postgres.User,
+			config.Postgres.DbName, config.Postgres.SSLMode, config.Postgres.Opts)
+		logging.Debugln("Opening database `", driverName, "` with options: ", redactedOptions)
+	} else {
+		logging.Debugln("Opening database `", driverName, "` with options: ", options)
+	}
 	client, err := ent.Open(driverName, options)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Potential fix for [https://github.com/browningluke/mangathr/security/code-scanning/2](https://github.com/browningluke/mangathr/security/code-scanning/2)

To fix the problem, we must prevent the database password (and other sensitive fields) from being logged in cleartext. Specifically, in internal/database/driver.go, we should avoid including the password in the logged `options` string. The best way to retain contextual logging while protecting sensitive data is to log a redacted string, e.g., replacing the actual password with "****". This can be achieved by constructing a string for log output where the password is excluded or replaced with a redacted value. We need to modify only the logging statement (line 55 of internal/database/driver.go) so that none of the fields containing secrets are exposed to logs, without changing the value used for actual connection purposes. This requires no new imports, only string formatting.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
