### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -1,4 +1,6 @@
 name: Go build & publish
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/browningluke/mangathr/security/code-scanning/1](https://github.com/browningluke/mangathr/security/code-scanning/1)

To fix this problem, we should add an explicit `permissions` block to the workflow. This block should be placed at the workflow root (top-level, before `jobs:`) to apply to all jobs unless some jobs need to override it. As a minimal starting point, `contents: read` is the recommended setting, as it provides adequate permissions for most read operations, including checkout and build steps. However, this workflow uploads assets to GitHub Releases using the `svenstaro/upload-release-action@v2` action, which requires publishing assets and may need write access to releases. According to the documentation, the required permissions for uploading to releases are `contents: write`. Therefore, the block should be:

```yaml
permissions:
  contents: write
```

This should be inserted after the `name` line and before the `on:` key. No new imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
